### PR TITLE
Bugfix - Fixed issue with window undefined while SSR

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -23,7 +23,12 @@ export async function getServerSideProps(context) {
 
 export default function Home({ data }) {
   // prettier-ignore
-  const [mode, setMode] = React.useState(getSystemDarkMode())
+  const [mode, setMode] = React.useState('light')
+  React.useEffect(() => {
+    if (typeof window === 'undefined') return
+    setMode(getSystemDarkMode())
+  }, [])
+
   const colorMode = React.useMemo(
     () => ({
       toggleColorMode: () => {


### PR DESCRIPTION
## What's in this PR?

- [ ] New Feature
- [x] Bug Fix
- [ ] Tech Debt/Refactor

### Description

App was throwing this error on initial page load:
```bash
ReferenceError: window is not defined
    at getSystemDarkMode (webpack-internal:///./themes/nasa.theme.js:50:5)
```

Fix is to use a `useEffect` which will detect if the `window` object is present.

### Checklist

- [x] All tests pass.
- [x] The code is linted and formatted correctly.
- [x] The documentation is updated, if necessary.
- [x] Any breaking changes are documented.
